### PR TITLE
Chore: Upgrade devcontainer image version

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3.9"
 services:
   react-native-simple-trial:
+    environment:
+      GH_TOKEN: ${GH_TOKEN}
     volumes:
       - type: volume
         source: vscode-extensions
@@ -8,10 +10,6 @@ services:
       - type: volume
         source: vscode-extensions-insiders
         target: /home/rn/.vscode-server-insiders/extensions
-      # - type: bind
-      #   source: ~/.config/gh
-      #   target: /home/rn/.config/gh
-      #   read_only: true
     command: /bin/sh -c "while sleep 1000; do :; done"
 
 volumes:

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   react-native-simple-trial:
-    image: utkusarioglu/react-native-android-devcontainer:1.0.16
+    image: utkusarioglu/react-native-android-devcontainer:1.0.17
     extra_hosts:
       - android-host:host-gateway
     volumes:


### PR DESCRIPTION
- Upgrade the devcontainer image version to 1.0.17.
- Include `GH_TOKEN` environment variable in the container to allow gh
  cli authorized access inside the container.
